### PR TITLE
Improve docs onboarding and deterministic criteria page generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
 # Assertive
 
-Assertive is a testing library that provides declarative assertions to you python tests.
+Assertive is a lightweight Python assertion library for writing declarative, composable test expectations.
 
+## Install
 
-## Criteria
-Criteria are declarative statements that can be used with assert statements to give a richer test experience.
-
-```python
-assert 5 == is_greater_than(4)
-assert 5 == is_odd()
-assert 5 != is_even()
+```bash
+pip install assertive
 ```
 
-Criteria can also be composed with logical operators to give a richer experience in writing tests
+## Quickstart
 
 ```python
-assert 5 == is_greater_than(4) & is_less_than(6) # Using AND
-assert 5 == is_even() | is_less_than(6) # Using OR
-assert 5 == is_even() ^ is_odd() # Using XOR
-assert 5 == ~is_even()  # Using INVERT
+from assertive import (
+    contains,
+    is_even,
+    is_gt,
+    is_lt,
+    regex,
+)
+
+assert 5 == is_gt(4)
+assert 5 == is_gt(4) & is_lt(6)
+assert 4 == is_even()
+assert "hello" == regex(r"^h.*o$")
+assert [1, 2, 3] == contains(2)
 ```
+
+You can compose criteria with boolean operators:
+
+```python
+assert 5 == is_gt(4) & is_lt(6)  # AND
+assert 5 == is_even() | is_lt(6)  # OR
+assert 5 == is_even() ^ is_lt(6)  # XOR
+assert 5 == ~is_even()  # NOT
+```
+
+## Documentation
+
+- User guide: <https://peter-daly.github.io/assertive/>
+- Criteria reference: <https://peter-daly.github.io/assertive/criteria/>
+- Writing custom criteria: <https://peter-daly.github.io/assertive/criteria/writing-custom-criteria/>

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -1,4 +1,18 @@
-# Criteria Modules
+# Criteria
 
-These are the current criteria inbuilt modules available
+Assertive ships with built-in criteria modules for common testing domains.
 
+## In-built modules
+
+- [basic](criteria/in-built/basic/)
+- [exception](criteria/in-built/exception/)
+- [list](criteria/in-built/list/)
+- [mapping](criteria/in-built/mapping/)
+- [mock](criteria/in-built/mock/)
+- [numeric](criteria/in-built/numeric/)
+- [object](criteria/in-built/object/)
+- [string](criteria/in-built/string/)
+
+## Custom criteria
+
+- [Writing custom criteria](criteria/writing-custom-criteria/)

--- a/docs/criteria/writing-custom-criteria.md
+++ b/docs/criteria/writing-custom-criteria.md
@@ -1,10 +1,73 @@
 # Writing custom criteria
 
-Assertive comes with it's own built in criteria but you can add your own custom criteria if you want add more richness to your assertions.
+Assertive includes many built-in criteria, but you can create your own when you want domain-specific assertions.
 
-There are a number of ways of creating custom criteria.
+The two most common approaches are:
 
-1. Extending the `Criteria` class and writing custom match methods
-2. Extending the `WrappedCriteria` class and composing a new criteria type from pre existing onces.
+1. Subclass `Criteria` and implement `_match`.
+2. Subclass `WrappedCriteria` and compose existing criteria.
+
+## 1) Subclassing `Criteria`
+
+Implement `_match(subject) -> bool` with your matching rule.
+
+```python
+from assertive import Criteria
 
 
+class is_uuid_like(Criteria):
+    def _match(self, subject) -> bool:
+        if not isinstance(subject, str):
+            return False
+
+        parts = subject.split("-")
+        return len(parts) == 5 and all(parts)
+
+
+assert "123e4567-e89b-12d3-a456-426614174000" == is_uuid_like()
+assert "not-a-uuid" != is_uuid_like()
+```
+
+## 2) Subclassing `WrappedCriteria`
+
+`WrappedCriteria` is useful when your custom criteria should delegate to existing criteria.
+
+```python
+from assertive import WrappedCriteria, is_gt, is_lt
+
+
+class is_small_positive_number(WrappedCriteria):
+    def __init__(self):
+        super().__init__(is_gt(0) & is_lt(10))
+
+
+assert 5 == is_small_positive_number()
+```
+
+## Composition with built-ins
+
+All criteria can be composed using `&`, `|`, `^`, and `~`.
+
+```python
+from assertive import is_gt, is_lt
+
+is_percentage = is_gt(0) & is_lt(101)
+
+assert 42 == is_percentage
+assert 120 != is_percentage
+```
+
+## Serialization support
+
+If your criteria should work with `assertive.serialize.serialize()` and `deserialize()`, implement:
+
+- `to_serialized(self) -> dict`
+- `from_serialized(cls, serialized: dict) -> Criteria`
+
+and add the class to `SERIALIZABLE_CRITERIA` in `assertive/serialize.py`.
+
+## Common pitfalls
+
+- **Type handling**: check `isinstance` when your criteria assumes a type.
+- **Mutable state**: avoid keeping state that changes match outcomes across assertions.
+- **Negation behavior**: if needed, override `_negated_match` for optimized or custom negation logic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,23 +1,45 @@
 # Assertive
 
-Assertive is a testing library that provides declarative assertions to you python tests.
+Assertive is a lightweight Python assertion library for writing declarative, composable test expectations.
 
+## Getting started
 
+Install:
 
-## Criteria
-Criteria are declarative statements that can be used with assert statements to give a richer test experience.
-
-```python
-assert 5 == is_greater_than(4)
-assert 5 == is_odd()
-assert 5 != is_even()
+```bash
+pip install assertive
 ```
 
-Criteria can also be composed with logical operators to give a richer experience in writing tests
+Use criteria objects directly with `assert`:
 
 ```python
-assert 5 == is_greater_than(4) & is_less_than(6) # Using AND
-assert 5 == is_even() | is_less_than(6) # Using OR
-assert 5 == is_even() ^ is_odd() # Using XOR
-assert 5 == ~is_even()  # Using INVERT
+from assertive import (
+    contains,
+    has_key_values,
+    is_even,
+    is_gt,
+    is_lt,
+    regex,
+)
+
+assert 5 == is_gt(4)
+assert 5 == is_gt(4) & is_lt(6)
+assert 4 == is_even()
+assert "hello" == regex(r"^h.*o$")
+assert [1, 2, 3] == contains(2)
+assert {"name": "Ada", "age": 37} == has_key_values({"name": "Ada"})
 ```
+
+You can compose criteria with logical operators:
+
+```python
+assert 5 == is_gt(4) & is_lt(6)  # AND
+assert 5 == is_even() | is_lt(6)  # OR
+assert 5 == is_even() ^ is_lt(6)  # XOR
+assert 5 == ~is_even()  # NOT
+```
+
+## Next steps
+
+- Browse built-in criteria: [Criteria reference](criteria/)
+- Build your own criteria: [Writing custom criteria](criteria/writing-custom-criteria/)

--- a/docs/scripts/gen_criteria_pages.py
+++ b/docs/scripts/gen_criteria_pages.py
@@ -9,7 +9,7 @@ criteria_path = root.joinpath("assertive/criteria")
 nav = mkdocs_gen_files.Nav()  # type: ignore
 
 criteria_file_path = "criteria.md"
-
+criteria_modules: list[str] = []
 
 for path in sorted(criteria_path.glob("*.py")):
     module_path = path.relative_to(root).with_suffix("")
@@ -23,12 +23,15 @@ for path in sorted(criteria_path.glob("*.py")):
 
     if module_name in ("__init__", "__main__", "utils"):
         continue
+
+    criteria_modules.append(module_name)
     nav["in-built", module_name] = nav_path.as_posix()
 
     with mkdocs_gen_files.open(full_doc_path, "w") as fd:
         ident = ".".join(module_parts)
         fd.write(f"::: {ident}")
-        fd.write("""
+        fd.write(
+            """
     options:
         show_root_heading: true
         show_symbol_type_toc: true
@@ -36,13 +39,20 @@ for path in sorted(criteria_path.glob("*.py")):
         members_order: source
     rendering:
         show_source: true
-""")
-
-    with mkdocs_gen_files.open(criteria_file_path, "a") as cd:
-        cd.write(f"- [{module_name}]({module_name})")
-        cd.write("\n")
+"""
+        )
 
     mkdocs_gen_files.set_edit_path(full_doc_path, path.relative_to(root))
+
+with mkdocs_gen_files.open(criteria_file_path, "w") as cd:
+    cd.write("# Criteria\n\n")
+    cd.write("Assertive ships with built-in criteria modules for common testing domains.\n\n")
+    cd.write("## In-built modules\n\n")
+    for module_name in criteria_modules:
+        cd.write(f"- [{module_name}](criteria/in-built/{module_name}/)\n")
+
+    cd.write("\n## Custom criteria\n\n")
+    cd.write("- [Writing custom criteria](criteria/writing-custom-criteria/)\n")
 
 with mkdocs_gen_files.open("criteria/SUMMARY.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())


### PR DESCRIPTION
### Motivation
- Improve first-time onboarding and examples so documentation uses accurate API names and shows how to get started quickly.
- Provide a stable, deterministic criteria index that links to generated per-module reference pages.
- Expand the custom-criteria guide with concrete, copy-pasteable examples and serialization guidance to reduce user confusion.

### Description
- Rewrote the project `README.md` with an `Install` section, an accurate `Quickstart` using real API names (`is_gt`, `is_lt`, etc.), and links to the docs pages; updated examples to use `contains`, `is_even`, `regex`, etc. (`README.md`).
- Updated the docs home `docs/index.md` to a Getting Started flow with corrected samples and links to the criteria reference and custom-criteria guide (`docs/index.md`).
- Rewrote and expanded the custom criteria guide to include concrete `Criteria` and `WrappedCriteria` examples, composition patterns, serialization hooks, and common pitfalls (`docs/criteria/writing-custom-criteria.md`).
- Made the criteria reference generation deterministic by changing `docs/scripts/gen_criteria_pages.py` to collect module names and write a canonical `docs/criteria.md` (instead of appending), and generate per-module pages under `criteria/in-built/` (`docs/scripts/gen_criteria_pages.py` and `docs/criteria.md`).

### Testing
- Ran the test suite with `pytest -q` which completed successfully with `103 passed`.
- Ran the docs generator with `python docs/scripts/gen_criteria_pages.py` which executed successfully and produced the updated `docs/criteria.md` and in-built module pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f0c675264832cad0553720895d898)